### PR TITLE
Update Sudoku Solver runtime to 49

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Sudoku Solver
+
+___A simple Sudoku Sovler___
+
+Sudoku Solver is a GTK4+libadwaita application that solves sudokus using the Wave Function Collapse Algorithm. 
+
+---
+
+## Manual Install and Run
+
+Make sure you follow the [setup guide for your Linux distribution](https://flathub.org/en/setup) before installing
+
+```
+flatpak install flathub io.gitlab.cyberphantom52.sudoku_solver
+flatpak run io.gitlab.cyberphantom52.sudoku_solver
+```
+
+## Building
+
+```
+git clone git@github.com:flathub/io.gitlab.cyberphantom52.sudoku_solver.git
+flatpak run org.flatpak.Builder build-dir --user --ccache --force-clean --install io.gitlab.cyberphantom52.sudoku_solver.json
+```
+
+---
+
+**Technologies**: GNOME, GTK4, Libadwaita, Rust

--- a/io.gitlab.cyberphantom52.sudoku_solver.json
+++ b/io.gitlab.cyberphantom52.sudoku_solver.json
@@ -1,7 +1,7 @@
 {
     "id" : "io.gitlab.cyberphantom52.sudoku_solver",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -28,18 +28,6 @@
         "*.a"
     ],
     "modules" : [
-        {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": ["*"],
-            "sources": [
-              {
-                "type": "git",
-                "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                "tag": "v0.6.0"
-              }
-            ]
-        },  
         {
             "name" : "sudoku-solver",
             "buildsystem" : "meson",


### PR DESCRIPTION
- Update Sudoku Solver runtime to 49
- Drop blueprint-compiler that already provided by the runtime
- Add a basic README.md