### PR TITLE
Drop ineffective cleanup commands and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,3 @@ flatpak run io.gitlab.cyberphantom52.sudoku_solver
 git clone git@github.com:flathub/io.gitlab.cyberphantom52.sudoku_solver.git
 flatpak run org.flatpak.Builder build-dir --user --ccache --force-clean --install io.gitlab.cyberphantom52.sudoku_solver.json
 ```
-
----
-
-**Technologies**: GNOME, GTK4, Libadwaita, Rust

--- a/io.gitlab.cyberphantom52.sudoku_solver.json
+++ b/io.gitlab.cyberphantom52.sudoku_solver.json
@@ -16,17 +16,6 @@
     "build-options" : {
         "append-path" : "/usr/lib/sdk/rust-stable/bin"
     },
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules" : [
         {
             "name" : "sudoku-solver",


### PR DESCRIPTION
- Drop ineffective cleanup commands
- Drop the technologies section from the README file to stop interfering with search results.